### PR TITLE
Branches matching fix

### DIFF
--- a/packages/go_router/example/README.md
+++ b/packages/go_router/example/README.md
@@ -31,13 +31,13 @@ An example to demonstrate how to use redirect to handle a synchronous sign-in fl
 An example to demonstrate how to use handle a sign-in flow with a stream authentication service.
 
 ## [Stateful Nested Navigation](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/stateful_shell_route.dart)
-`flutter run lib/stateful_nested_navigation.dart`
+`flutter run lib/stateful_shell_route.dart`
 
 An example to demonstrate how to use a `StatefulShellRoute` to create stateful nested navigation, with a
 `BottomNavigationBar`.
 
 ## [Dynamic Stateful Nested Navigation](https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/stateful_shell_route_dynamic.dart)
-`flutter run lib/dynamic_stateful_shell_branches.dart`
+`flutter run lib/stateful_shell_route_dynamic.dart`
 
 An example to demonstrate how to use a `StatefulShellRoute` to create stateful nested navigation, with a
 `BottomNavigationBar` and a dynamic set of tabs and Navigators.

--- a/packages/go_router/example/lib/stateful_shell_route.dart
+++ b/packages/go_router/example/lib/stateful_shell_route.dart
@@ -74,119 +74,130 @@ class NestedTabNavigationExampleApp extends StatelessWidget {
   final GoRouter _router = GoRouter(
     initialLocation: '/a',
     routes: <RouteBase>[
-      StatefulShellRoute(
-        routes: <RouteBase>[
-          GoRoute(
-            /// The screen to display as the root in the first tab of the
-            /// bottom navigation bar.
-            path: '/a',
-            builder: (BuildContext context, GoRouterState state) =>
-                const RootScreen(label: 'A', detailsPath: '/a/details'),
-            routes: <RouteBase>[
-              /// The details screen to display stacked on navigator of the
-              /// first tab. This will cover screen A but not the application
-              /// shell (bottom navigation bar).
-              GoRoute(
-                path: 'details',
-                builder: (BuildContext context, GoRouterState state) =>
-                    DetailsScreen(label: 'A', extra: state.extra),
-              ),
-            ],
-          ),
-          GoRoute(
-            /// The screen to display as the root in the second tab of the
-            /// bottom navigation bar.
-            path: '/b',
-            builder: (BuildContext context, GoRouterState state) =>
-                const RootScreen(
-              label: 'B',
-              detailsPath: '/b/details/1',
-              secondDetailsPath: '/b/details/2',
-            ),
-            routes: <RouteBase>[
-              GoRoute(
-                path: 'details/:param',
-                builder: (BuildContext context, GoRouterState state) =>
-                    DetailsScreen(
-                  label: 'B',
-                  param: state.params['param'],
-                  extra: state.extra,
-                ),
-              ),
-            ],
-          ),
-          StatefulShellRoute(
+      GoRoute(
+          path: '/',
+          builder: (BuildContext context, GoRouterState state) =>
+              const SizedBox(),
+          routes: [
+            StatefulShellRoute(
               routes: <RouteBase>[
                 GoRoute(
-                  path: '/c1',
+                  /// The screen to display as the root in the first tab of the
+                  /// bottom navigation bar.
+                  path: 'a',
                   builder: (BuildContext context, GoRouterState state) =>
-                      const TabScreen(label: 'C1', detailsPath: '/c1/details'),
+                      const RootScreen(label: 'A', detailsPath: '/a/details'),
                   routes: <RouteBase>[
+                    /// The details screen to display stacked on navigator of the
+                    /// first tab. This will cover screen A but not the application
+                    /// shell (bottom navigation bar).
                     GoRoute(
                       path: 'details',
                       builder: (BuildContext context, GoRouterState state) =>
-                          DetailsScreen(
-                        label: 'C1',
-                        extra: state.extra,
-                        withScaffold: false,
-                      ),
+                          DetailsScreen(label: 'A', extra: state.extra),
                     ),
                   ],
                 ),
                 GoRoute(
-                  path: '/c2',
+                  /// The screen to display as the root in the second tab of the
+                  /// bottom navigation bar.
+                  path: 'b',
                   builder: (BuildContext context, GoRouterState state) =>
-                      const TabScreen(label: 'C2', detailsPath: '/c2/details'),
+                      const RootScreen(
+                    label: 'B',
+                    detailsPath: '/b/details/1',
+                    secondDetailsPath: '/b/details/2',
+                  ),
                   routes: <RouteBase>[
                     GoRoute(
-                      path: 'details',
+                      path: 'details/:param',
                       builder: (BuildContext context, GoRouterState state) =>
                           DetailsScreen(
-                        label: 'C2',
+                        label: 'B',
+                        param: state.params['param'],
                         extra: state.extra,
-                        withScaffold: false,
                       ),
                     ),
                   ],
                 ),
+                StatefulShellRoute(
+                    routes: <RouteBase>[
+                      GoRoute(
+                        path: 'c1',
+                        builder: (BuildContext context, GoRouterState state) =>
+                            const TabScreen(
+                                label: 'C1', detailsPath: '/c1/details'),
+                        routes: <RouteBase>[
+                          GoRoute(
+                            path: 'details',
+                            builder:
+                                (BuildContext context, GoRouterState state) =>
+                                    DetailsScreen(
+                              label: 'C1',
+                              extra: state.extra,
+                              withScaffold: false,
+                            ),
+                          ),
+                        ],
+                      ),
+                      GoRoute(
+                        path: 'c2',
+                        builder: (BuildContext context, GoRouterState state) =>
+                            const TabScreen(
+                                label: 'C2', detailsPath: '/c2/details'),
+                        routes: <RouteBase>[
+                          GoRoute(
+                            path: 'details',
+                            builder:
+                                (BuildContext context, GoRouterState state) =>
+                                    DetailsScreen(
+                              label: 'C2',
+                              extra: state.extra,
+                              withScaffold: false,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                    branches: _topNavBranches,
+                    builder: (BuildContext context, GoRouterState state,
+                        Widget child) {
+                      /// For this nested StatefulShellRoute we are using a custom
+                      /// container (TabBarView) for the branch navigators, and thus
+                      /// ignoring the default navigator contained passed to the
+                      /// builder. Custom implementation can access the branch
+                      /// navigators via the StatefulShellRouteState
+                      /// (see TabbedRootScreen for details).
+                      return const TabbedRootScreen();
+                    }),
               ],
-              branches: _topNavBranches,
+              branches: _bottomNavBranches,
               builder:
                   (BuildContext context, GoRouterState state, Widget child) {
-                /// For this nested StatefulShellRoute we are using a custom
-                /// container (TabBarView) for the branch navigators, and thus
-                /// ignoring the default navigator contained passed to the
-                /// builder. Custom implementation can access the branch
-                /// navigators via the StatefulShellRouteState
-                /// (see TabbedRootScreen for details).
-                return const TabbedRootScreen();
-              }),
-        ],
-        branches: _bottomNavBranches,
-        builder: (BuildContext context, GoRouterState state, Widget child) {
-          return ScaffoldWithNavBar(body: child);
-        },
+                return ScaffoldWithNavBar(body: child);
+              },
 
-        /// If you need to create a custom container for the branch routes, to
-        /// for instance setup custom animations, you can implement your builder
-        /// something like below (see _AnimatedRouteBranchContainer). Note that
-        /// in this case, you should not add the Widget provided in the child
-        /// parameter of the builder to the widget tree. Instead, you should use
-        /// the child widgets of each branch
-        /// (see StatefulShellRouteState.children).
-        // builder: (BuildContext context, GoRouterState state, Widget child) {
-        //   return ScaffoldWithNavBar(
-        //     body: _AnimatedRouteBranchContainer(),
-        //   );
-        // },
+              /// If you need to create a custom container for the branch routes, to
+              /// for instance setup custom animations, you can implement your builder
+              /// something like below (see _AnimatedRouteBranchContainer). Note that
+              /// in this case, you should not add the Widget provided in the child
+              /// parameter of the builder to the widget tree. Instead, you should use
+              /// the child widgets of each branch
+              /// (see StatefulShellRouteState.children).
+              // builder: (BuildContext context, GoRouterState state, Widget child) {
+              //   return ScaffoldWithNavBar(
+              //     body: _AnimatedRouteBranchContainer(),
+              //   );
+              // },
 
-        /// If you need to customize the Page for StatefulShellRoute, pass a
-        /// pageBuilder function in addition to the builder, for example:
-        // pageBuilder:
-        //     (BuildContext context, GoRouterState state, Widget statefulShell) {
-        //   return NoTransitionPage<dynamic>(child: statefulShell);
-        // },
-      ),
+              /// If you need to customize the Page for StatefulShellRoute, pass a
+              /// pageBuilder function in addition to the builder, for example:
+              // pageBuilder:
+              //     (BuildContext context, GoRouterState state, Widget statefulShell) {
+              //   return NoTransitionPage<dynamic>(child: statefulShell);
+              // },
+            ),
+          ]),
     ],
   );
 

--- a/packages/go_router/lib/src/route.dart
+++ b/packages/go_router/lib/src/route.dart
@@ -755,7 +755,7 @@ class StatefulShellBranch {
   /// GoRouterState.
   bool isBranchFor(GoRouterState state) {
     final String? match = rootLocations
-        .firstWhereOrNull((String e) => state.subloc.startsWith(e));
+        .firstWhereOrNull((String e) => state.location.startsWith(e));
     return match != null;
   }
 


### PR DESCRIPTION
Hello @tolo. I tried to integrate your `StatefulShellRoute`, but I found an error that is described below in the screenshot.
![telegram-cloud-photo-size-2-5226468788684308854-y](https://user-images.githubusercontent.com/43740557/206322034-43da0d59-0727-45b7-965b-a72d0a05c141.jpg)

And in the end I started comparing with your example and found this: 

If you wrap `StatefulShellRoute` in `GoRoute`, then your example will have the same error (I updated the example in PR).

This problem is related to the fact that the isBranchFor method does not find a match for the following example:

```dart
state.subloc.startWith(e) // false
// 'a'.startWith('/a')
```

Since there is no more '/' in `state.subloc` after the `GoRoute(path: '/')` wrapper, it follows that `isBranchFor` will always return `false`.